### PR TITLE
複数種類の通知機能を追加

### DIFF
--- a/6_1/ch14/Gemfile
+++ b/6_1/ch14/Gemfile
@@ -47,3 +47,5 @@ end
 
 # Windows ではタイムゾーン情報用の tzinfo-data gem を含める必要があります
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'sidekiq'

--- a/6_1/ch14/Gemfile.lock
+++ b/6_1/ch14/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
       rake (< 13.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crass (1.0.6)
     erubi (1.10.0)
     execjs (2.8.1)
@@ -213,6 +214,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.5.1)
     regexp_parser (1.8.2)
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.4)
@@ -236,6 +238,10 @@ GEM
       childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
     shellany (0.0.1)
+    sidekiq (6.4.0)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -277,6 +283,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-18
   x86_64-linux
 
@@ -304,6 +311,7 @@ DEPENDENCIES
   rails-controller-testing (= 1.0.4)
   sass-rails (= 5.1.0)
   selenium-webdriver (= 3.142.4)
+  sidekiq
   spring (= 2.1.0)
   spring-watcher-listen (= 2.0.1)
   sqlite3 (= 1.4.1)

--- a/6_1/ch14/app/controllers/account_activations_controller.rb
+++ b/6_1/ch14/app/controllers/account_activations_controller.rb
@@ -4,6 +4,7 @@ class AccountActivationsController < ApplicationController
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
       user.activate
+      Users::LoginNotificationJob.perform_now(user)
       log_in user
       flash[:success] = "Account activated!"
       redirect_to user

--- a/6_1/ch14/app/controllers/relationships_controller.rb
+++ b/6_1/ch14/app/controllers/relationships_controller.rb
@@ -4,6 +4,9 @@ class RelationshipsController < ApplicationController
   def create
     @user = User.find(params[:followed_id])
     current_user.follow(@user)
+    Users::FollowedNotificationJob.set(
+      wait: UserNotification::FOLLOWED_WITHIN_MINUTES
+    ).perform_later(current_user)
     respond_to do |format|
       format.html { redirect_to @user }
       format.js

--- a/6_1/ch14/app/jobs/users/followed_notification_job.rb
+++ b/6_1/ch14/app/jobs/users/followed_notification_job.rb
@@ -1,0 +1,21 @@
+class Users::FollowedNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(user)
+    followers = Relationship.recent_followers(user.id, UserNotification::FOLLOWED_WITHIN_MINUTES)
+    return if followers.size.zero?
+
+    UserNotification.create!(
+      user: user,
+      notification_type: :followed,
+      message: create_massage(followers)
+    )
+  end
+
+  private
+
+  def create_massage(followers)
+    return "#{followers.pop.name}さんにフォローされました" if followers.size == 1
+    return "#{followers.pop.name}さん他#{followers.size}名にフォローされました" if followers.size > 1
+  end
+end

--- a/6_1/ch14/app/jobs/users/login_notification_job.rb
+++ b/6_1/ch14/app/jobs/users/login_notification_job.rb
@@ -1,0 +1,19 @@
+class Users::LoginNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(user)
+    return if exists_login_user_notification?
+
+    UserNotification.create!(
+      user: user,
+      notification_type: :login,
+      message: '初回ログインありがとうございます。'
+    )
+  end
+
+  private
+
+  def exists_login_user_notification?
+    UserNotification.where(user: @user, notification_type: :login).exists?
+  end
+end

--- a/6_1/ch14/app/models/relationship.rb
+++ b/6_1/ch14/app/models/relationship.rb
@@ -1,6 +1,13 @@
 class Relationship < ApplicationRecord
-  belongs_to :follower, class_name: "User"
-  belongs_to :followed, class_name: "User"
+  belongs_to :follower, class_name: 'User'
+  belongs_to :followed, class_name: 'User'
   validates :follower_id, presence: true
   validates :followed_id, presence: true
+
+  def self.recent_followers(followed_id, within_time)
+    relations = where(followed_id: followed_id).order(created_at: :desc)
+    relations.select do |relation|
+      relation.created_at >= (Time.current - within_time)
+    end.map(&:follower)
+  end
 end

--- a/6_1/ch14/app/models/user_notification.rb
+++ b/6_1/ch14/app/models/user_notification.rb
@@ -1,0 +1,9 @@
+class UserNotification < ApplicationRecord
+  belongs_to :user
+
+  enum notification_type: %i[login followed]
+
+  validates :message, presence: true
+
+  FOLLOWED_WITHIN_MINUTES = 5.minutes
+end

--- a/6_1/ch14/config/application.rb
+++ b/6_1/ch14/config/application.rb
@@ -21,5 +21,7 @@ module SampleApp
 
     # 認証トークンをremoteフォームに埋め込む
     config.action_view.embed_authenticity_token_in_remote_forms = true
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/6_1/ch14/db/migrate/20220123230409_create_user_notifications.rb
+++ b/6_1/ch14/db/migrate/20220123230409_create_user_notifications.rb
@@ -1,0 +1,11 @@
+class CreateUserNotifications < ActiveRecord::Migration[6.1]
+  def change
+    create_table :user_notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.integer :notification_type, null: false
+      t.text :message, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/6_1/ch14/db/schema.rb
+++ b/6_1/ch14/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_032413) do
+ActiveRecord::Schema.define(version: 2022_01_23_230409) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -59,6 +59,15 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
     t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
+  create_table "user_notifications", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "notification_type", null: false
+    t.text "message", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_notifications_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
@@ -78,4 +87,5 @@ ActiveRecord::Schema.define(version: 2021_11_30_032413) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "microposts", "users"
+  add_foreign_key "user_notifications", "users"
 end

--- a/6_1/ch14/test/jobs/users/followed_notification_job_test.rb
+++ b/6_1/ch14/test/jobs/users/followed_notification_job_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class Users::FollowedNotificationJobTest < ActiveJob::TestCase
+  setup do
+    @user = users(:michael)
+  end
+
+  test 'uer_notification is created by job execution' do
+    Relationship.delete_all
+
+    Relationship.create!(
+      follower_id: users(:archer).id,
+      followed_id: @user.id
+    )
+
+    count = UserNotification.count
+    Users::FollowedNotificationJob.perform_now(@user)
+    assert_equal count + 1, UserNotification.count
+
+    user_notification = UserNotification.first
+    assert_equal user_notification.notification_type, 'followed'
+    assert_equal user_notification.message, 'Sterling Archerさんにフォローされました'
+  end
+
+  test 'uer_notification with 3 followers is created by job execution' do
+    Relationship.delete_all
+
+    Relationship.create!(
+      follower_id: users(:archer).id,
+      followed_id: @user.id
+    )
+
+    Relationship.create!(
+      follower_id: users(:lana).id,
+      followed_id: @user.id
+    )
+
+    Relationship.create!(
+      follower_id: users(:malory).id,
+      followed_id: @user.id
+    )
+
+    count = UserNotification.count
+    Users::FollowedNotificationJob.perform_now(@user)
+    assert_equal count + 1, UserNotification.count
+
+    user_notification = UserNotification.first
+    assert_equal user_notification.notification_type, 'followed'
+    assert_equal user_notification.message, 'Sterling Archerさん他2名にフォローされました'
+  end
+end

--- a/6_1/ch14/test/jobs/users/login_notification_job_test.rb
+++ b/6_1/ch14/test/jobs/users/login_notification_job_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Users::LoginNotificationJobTest < ActiveJob::TestCase
+  setup do
+    @user = users(:michael)
+  end
+
+  test 'uer_notification is created by job execution' do
+    count = UserNotification.count
+    Users::LoginNotificationJob.perform_now(@user)
+    assert_equal count + 1, UserNotification.count
+
+    user_notification = UserNotification.first
+    assert_equal user_notification.notification_type, 'login'
+    assert_equal user_notification.message, '初回ログインありがとうございます。'
+  end
+end

--- a/6_1/ch14/test/models/relationship_test.rb
+++ b/6_1/ch14/test/models/relationship_test.rb
@@ -20,4 +20,40 @@ class RelationshipTest < ActiveSupport::TestCase
     @relationship.followed_id = nil
     assert_not @relationship.valid?
   end
+
+  test "recent_followers within 5 minutes are counted" do
+    Relationship.destroy_all
+    @relationship.save
+
+    Relationship.create!(
+      follower_id: users(:lana).id,
+      followed_id: users(:archer).id
+    )
+    Relationship.create!(
+      follower_id: users(:archer).id,
+      followed_id: users(:lana).id
+    )
+
+    assert_equal 2, Relationship.recent_followers(users(:archer), 5.minutes).size
+    assert_equal 1, Relationship.recent_followers(users(:lana), 5.minutes).size
+  end
+
+  test "recent_followers after 5 minutes are not counted" do
+    Relationship.destroy_all
+    @relationship.save
+
+    Relationship.create!(
+      follower_id: users(:lana).id,
+      followed_id: users(:archer).id,
+      created_at: Time.current - 5.minutes
+    )
+    Relationship.create!(
+      follower_id: users(:archer).id,
+      followed_id: users(:lana).id,
+      created_at: Time.current - 5.minutes
+    )
+
+    assert_equal 1, Relationship.recent_followers(users(:archer), 5.minutes).size
+    assert_equal 0, Relationship.recent_followers(users(:lana), 5.minutes).size
+  end
 end


### PR DESCRIPTION
# 概要

RailsTutorialの最終章で完成する下記アプリケーションに対して、以下のユースケースに対応できるよう機能拡張する。

# Repository

[https://github.com/SchooLynk/sample_apps/tree/main/6_1/ch14](https://github.com/SchooLynk/sample_apps/tree/main/6_1/ch14)

# 要件

1. フォローされた際に通知が作られる（「○○さんにフォローされました」）
2. 初回ログイン時に通知が作られる（「初回ログインありがとうございます。」）
3. 5分以内に同じ種類の通知が発生する場合は一つの通知にまとめられる（「○○さん他3名にフォローされました」）
4. 1,2,3の通知を同じUIで一覧できる

但し、通知を確認するControllerやViewは作らなくてOK。データが作られる所までをコーディングテストのスコープとする。

通知=FBのお知らせ（ベルマーク）のようなもの

# 設計概要

- 要件よりリアルタイムの通知が必要ないという前提で、Sidekiqを導入してジョブ形式で通知機能を実装しました。